### PR TITLE
Add test code coverage reporting to Code Climate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Gemfile.lock
+
+# Ignore SimpleCov coverage output.
+coverage

--- a/resolver_app_config.gemspec
+++ b/resolver_app_config.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails', '~> 5'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,3 +98,10 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+if ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/spec/'
+  end
+end


### PR DESCRIPTION
This commit adds support for calculating test code coverage using SimpleCov and submitting the results to Code Climate for both immediate reporting and longer-term trends.