### PR TITLE
Extend HSTS max time and enable preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+* Extend HSTS header to 1 year with preloading.
+* Fix `require` in `bin/console`.
+
 ## 0.0.2
 
 * Add X-Content-Type-Options, X-Frame-Options and X-XSS-Protection headers to all HTTP responses.

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "govuk_app_config"
+require "resolver_app_config"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/resolver_app_config/resolver_http_headers.rb
+++ b/lib/resolver_app_config/resolver_http_headers.rb
@@ -8,9 +8,9 @@ module ResolverHTTPHeaders
   # need to reiterate these ones.
   #
   # Strict-Transport-Security - this header sets options for HSTS
-  # (HTTP strict transport security). This is currently set to a short
-  # time (30 seconds) and specifically excludes all subdomains and browser
-  # preloading for testing purposes.
+  # (HTTP strict transport security). This is currently set to 1 year
+  # with preloading enabled. Subdomains are disabled since they are under
+  # the control of various teams.
   #
   # X-Content-Type-Options - this header opts the site out of automatic
   # MIME type sniffing, specifically in Internet Explorer.
@@ -29,7 +29,7 @@ module ResolverHTTPHeaders
   # * Expect-CT
   def self.configure
     Rails.application.config.action_dispatch.default_headers = {
-      'Strict-Transport-Security' => 'max-age=30',
+      'Strict-Transport-Security' => 'max-age=31536000; preload',
       'X-Content-Type-Options' => 'nosniff',
       'X-Frame-Options' => 'SAMEORIGIN',
       'X-XSS-Protection' => '1; mode=block',

--- a/lib/resolver_app_config/version.rb
+++ b/lib/resolver_app_config/version.rb
@@ -1,3 +1,3 @@
 module ResolverAppConfig
-  VERSION = '0.0.2'
+  VERSION = '0.1.0'
 end

--- a/spec/lib/resolver_http_headers_spec.rb
+++ b/spec/lib/resolver_http_headers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ResolverHTTPHeaders do
     it 'adds a Strict-Transport-Security header' do
       headers = ResolverHTTPHeaders.configure
       expect(Rails.application.config.action_dispatch.default_headers).to match({
-        'Strict-Transport-Security' => 'max-age=30',
+        'Strict-Transport-Security' => 'max-age=31536000; preload',
         'X-Content-Type-Options' => 'nosniff',
         'X-Frame-Options' => 'SAMEORIGIN',
         'X-XSS-Protection' => '1; mode=block',


### PR DESCRIPTION
This commit extends the HSTS max time from 30 seconds to 1 year since it has now been proven to work in production. 1 year is the recommended value for this header and is the timespan within which browsers will only attempt to connect using HTTPS. Preloading is also enabled so that anyone visiting the site for the first time will also benefit from this protection.